### PR TITLE
Feat port selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
-# PMSin
+# PMSim
 
-PMSin is a simulation tool with a web interface that simulates three-phase power meters. It allows users to adjust values such as Power, Voltage, and Current through the web UI. Additionally, it provides a FastAPI for direct control of the simulated power meter, offering flexibility for various use cases. A python backend provides the API and runs the simulations, while the Frontend accessing the API is provided by vite. The configurated simulation(s) are stored in a file persistently.
+PMSim is a simulation tool that provides a web interface and a backend to run simulations of three-phase power meters as well as provides a modbus tcp or rtu interface (dependent on how the power meter that is simulated is set up). It allows users to adjust values such as Power, Voltage, and Current through the web UI. Additionally, it provides an API for direct control of the simulated power meter, offering flexibility for various use cases. A python backend provides the API and runs the simulations, while the Frontend accessing the API is provided by vite. The configurated simulation(s) are stored in a file persistently.
 
 ## Features
 
 - Easy to use web UI for monitoring, configuring, and modifying simulations.
 - For each simulation, modify power, voltage, current phase-wise, and modify the serial number.
+- Selection of serial interface of available interfaces per simulation (for Modbus RTU only)
 - Start/Stop/Remove simulations individually.
 - Ability to add/run multiple simulations.
-- API to access without a graphical user interface.
+- API to access and modify without a graphical user interface.
 
 ## Setup
 

--- a/backend/abstract_simulation.py
+++ b/backend/abstract_simulation.py
@@ -1,4 +1,3 @@
-from http.server import HTTPServer, BaseHTTPRequestHandler
 from typing import Tuple
 import threading
 import uuid
@@ -14,6 +13,7 @@ class AbstractSimulation(ABC):
         self.power = [230.0, 230.0, 230.0]
         self.serial_number = "1234567"
         self.brand = "Brand1"
+        self.port = ""
         self.is_running = False
         self.simulation_type = "steady"
         self.simulation_thread = None
@@ -51,11 +51,21 @@ class AbstractSimulation(ABC):
 
     def get_brand(self) -> str:
         return self.brand
-
+    
     def set_brand(self, brand: str):
         if brand not in ["Brand1", "Brand2"]:
             raise ValueError("Invalid brand")
         self.brand = brand
+
+    def get_port(self) -> str:
+        return self.port
+    
+    def set_port(self, port: str):
+        self.port = port
+        # restart the simulation if it is running
+        if self.is_running:
+            self.set_simulation_state(False)
+            self.set_simulation_state(True)
 
     def set_simulation_type(self, sim_type: str):
         if sim_type not in ["steady", "fluctuating", "overload", "brownout"]:
@@ -84,6 +94,7 @@ class AbstractSimulation(ABC):
             "power": self.get_power(),
             "serialNumber": self.get_serial_number(),
             "brand": self.get_brand(),
+            "port": self.get_port(),
             "isRunning": self.is_running,
             "simulationType": self.simulation_type,
             "id": self.id,
@@ -95,7 +106,7 @@ class AbstractSimulation(ABC):
             "id": self.id,
             "protocol": self.protocol,
             "serialNumber": self.serial_number,
-            "brand": self.brand,
+            "port": self.get_port(),
             "isRunning": self.is_running,
             "simulationType": self.simulation_type
         }

--- a/backend/dummy_power_meter_simulation.py
+++ b/backend/dummy_power_meter_simulation.py
@@ -7,8 +7,8 @@ from abstract_simulation import AbstractSimulation
 class DummyPowerMeterSimulation(AbstractSimulation):
     def __init__(self, protocol: str):
         super().__init__(protocol)
-        if protocol != "dummy":
-            raise ValueError(f"DummyPowerMeterSimulation only supports 'dummy' protocol, not '{protocol}'")
+        #if protocol != "dummy":
+        #    raise ValueError(f"DummyPowerMeterSimulation only supports 'dummy' protocol, not '{protocol}'")
 
     def run_simulation(self):
         while self.is_running:

--- a/backend/helpers.py
+++ b/backend/helpers.py
@@ -1,0 +1,5 @@
+import serial.tools.list_ports
+
+def list_serial_interfaces():
+    """List available serial interfaces."""
+    return [port.device for port in serial.tools.list_ports.comports()]

--- a/backend/request_handler.py
+++ b/backend/request_handler.py
@@ -1,9 +1,7 @@
 import json
-from http.server import BaseHTTPRequestHandler, HTTPServer
-from typing import Dict
-from dummy_power_meter_simulation import DummyPowerMeterSimulation
+from http.server import BaseHTTPRequestHandler
 from simulation_manager import SimulationManager
-from abstract_simulation import AbstractSimulation
+import helpers
 
 simulation_manager = SimulationManager()
 
@@ -35,6 +33,12 @@ class RequestHandler(BaseHTTPRequestHandler):
                 self.wfile.write(json.dumps(simulator.get_data()).encode())
             else:
                 self.send_error(404)
+        elif self.path == '/serial':
+            self.send_response(200)
+            self.send_cors_headers()
+            self.send_header('Content-type', 'application/json')
+            self.end_headers()
+            self.wfile.write(json.dumps({"devices": helpers.list_serial_interfaces()}).encode())
         else:
             self.send_error(404)
 
@@ -79,6 +83,8 @@ class RequestHandler(BaseHTTPRequestHandler):
                     simulator.set_serial_number(data['serialNumber'])
                 elif action == 'brand':
                     simulator.set_brand(data['brand'])
+                elif action == 'port':
+                    simulator.set_port(data['port'])
                 elif action == 'simulation-type':
                     simulator.set_simulation_type(data['type'])
                 elif action == 'simulation-state':

--- a/backend/simulation_manager.py
+++ b/backend/simulation_manager.py
@@ -18,7 +18,7 @@ class SimulationManager:
                 config = json.load(f)
                 for instance in config['instances']:
                     protocol = instance['protocol']
-                    if protocol == 'dummy': # Select simulation class based on protocol
+                    if protocol == 'ModbusMTU' or 'ModbusTCP': # Select simulation class based on protocol
                         simulator = DummyPowerMeterSimulation(protocol)
                     else:
                         # Default to dummy if protocol is unknown, or handle error as needed
@@ -39,12 +39,12 @@ class SimulationManager:
             json.dump(config, f)
 
     def add_simulator(self, protocol: str) -> str:
-        if protocol == 'dummy': # Select simulation class based on protocol
+        if protocol == 'ModbusMTU' or 'ModbusTCP': # Select simulation class based on protocol
             simulator = DummyPowerMeterSimulation(protocol)
         else:
             # Default to dummy if protocol is unknown, or handle error as needed
             simulator = DummyPowerMeterSimulation("dummy") # Or raise an error
-            print(f"Warning: Unknown protocol '{protocol}', defaulting to dummy simulation.")
+            print(f"Warning: Unknown protocol '{protocol}' in config, defaulting to dummy simulation.")
 
         self.simulators[simulator.id] = simulator
         self.save_config()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,9 @@
 fastapi==0.109.2
 uvicorn==0.27.1
 pydantic==2.6.1
+pymodbus==3.8.6
+pyserial==3.5
+
+
+
+

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -85,3 +85,11 @@ export async function setSimulationState(simulatorId: string, isRunning: boolean
     body: JSON.stringify({ isRunning }),
   });
 }
+
+export async function setSimulationPort(simulatorId: string, port: string): Promise<void> {
+  await fetch(`${API_BASE}/simulator/${simulatorId}/port`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ port }),
+  });
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -4,6 +4,7 @@ export interface PowerMeterData {
   power: [number, number, number];
   serialNumber: string;
   brand: 'Brand1' | 'Brand2';
+  port: string;
   isRunning: boolean;
 }
 
@@ -24,6 +25,7 @@ export interface SimulatorInstance {
   protocol: SimulatorProtocol;
   serialNumber: string;
   brand: 'Brand1' | 'Brand2';
+  port: string
   isRunning: boolean;
   simulationType: SimulationType;
 }


### PR DESCRIPTION
This pull request includes several changes to enhance the functionality and flexibility of the PMSim tool. The most important changes focus on adding support for selecting serial interfaces, updating the backend to handle new configurations, and improving the frontend to accommodate these updates.

Enhancements to the backend:

* [`backend/abstract_simulation.py`](diffhunk://#diff-371849d09583087944dc8adb010fe0b73aa20b2cc22b628be3334fa9dd2a0383R16): Added `port` attribute and methods `get_port` and `set_port`. Updated `get_data` and `to_dict` methods to include the `port` attribute. [[1]](diffhunk://#diff-371849d09583087944dc8adb010fe0b73aa20b2cc22b628be3334fa9dd2a0383R16) [[2]](diffhunk://#diff-371849d09583087944dc8adb010fe0b73aa20b2cc22b628be3334fa9dd2a0383R60-R69) [[3]](diffhunk://#diff-371849d09583087944dc8adb010fe0b73aa20b2cc22b628be3334fa9dd2a0383R97) [[4]](diffhunk://#diff-371849d09583087944dc8adb010fe0b73aa20b2cc22b628be3334fa9dd2a0383L98-R109)
* [`backend/helpers.py`](diffhunk://#diff-1a796267ece6a2d6d02090d0f5624b6003b7c18026b9a0d411dab8234f922adbR1-R5): Added a new function `list_serial_interfaces` to list available serial interfaces.
* [`backend/request_handler.py`](diffhunk://#diff-6f2cb483ce9ded475a7bb01c80a8563fb5801bfe2740399bd63722394202a184R36-R41): Updated `do_GET` and `do_POST` methods to handle requests for serial interfaces and setting the port. [[1]](diffhunk://#diff-6f2cb483ce9ded475a7bb01c80a8563fb5801bfe2740399bd63722394202a184R36-R41) [[2]](diffhunk://#diff-6f2cb483ce9ded475a7bb01c80a8563fb5801bfe2740399bd63722394202a184R86-R87)
* [`backend/simulation_manager.py`](diffhunk://#diff-3cdcc7cdfcb02ae82531a691f495f319a1647ec1ae0607c608a8c1a75cc89700L21-R21): Modified to select the appropriate simulation class based on the protocol, including new protocols `ModbusMTU` and `ModbusTCP`. [[1]](diffhunk://#diff-3cdcc7cdfcb02ae82531a691f495f319a1647ec1ae0607c608a8c1a75cc89700L21-R21) [[2]](diffhunk://#diff-3cdcc7cdfcb02ae82531a691f495f319a1647ec1ae0607c608a8c1a75cc89700L42-R47)

Improvements to the frontend:

* [`src/lib/SimulatorCard.svelte`](diffhunk://#diff-96706e6daa1a507daf88bc45ed9a3cfcaa2ca3441f94a0ca54d224af505d6eadL20-R21): Added functionality to fetch and display available serial ports, and allow users to select and set the port for simulations. [[1]](diffhunk://#diff-96706e6daa1a507daf88bc45ed9a3cfcaa2ca3441f94a0ca54d224af505d6eadL20-R21) [[2]](diffhunk://#diff-96706e6daa1a507daf88bc45ed9a3cfcaa2ca3441f94a0ca54d224af505d6eadL32-L41) [[3]](diffhunk://#diff-96706e6daa1a507daf88bc45ed9a3cfcaa2ca3441f94a0ca54d224af505d6eadL50-L55) [[4]](diffhunk://#diff-96706e6daa1a507daf88bc45ed9a3cfcaa2ca3441f94a0ca54d224af505d6eadL77-R97) [[5]](diffhunk://#diff-96706e6daa1a507daf88bc45ed9a3cfcaa2ca3441f94a0ca54d224af505d6eadL117) [[6]](diffhunk://#diff-96706e6daa1a507daf88bc45ed9a3cfcaa2ca3441f94a0ca54d224af505d6eadL149-R164) [[7]](diffhunk://#diff-96706e6daa1a507daf88bc45ed9a3cfcaa2ca3441f94a0ca54d224af505d6eadR245-R271) [[8]](diffhunk://#diff-96706e6daa1a507daf88bc45ed9a3cfcaa2ca3441f94a0ca54d224af505d6eadL262) [[9]](diffhunk://#diff-96706e6daa1a507daf88bc45ed9a3cfcaa2ca3441f94a0ca54d224af505d6eadL277-L280)
* [`src/lib/api.ts`](diffhunk://#diff-400f714a60b9cf9cb8d716a1010cd6de05f9841d153876783ad7442be601af0dR88-R95): Added a new function `setSimulationPort` to update the port of a simulation.
* [`src/lib/types.ts`](diffhunk://#diff-b8b77f5be18cf56dca425b3a5b8e9d2e754dd37fe0e3612b95cd4e9bccda08a5R7): Updated `PowerMeterData` and `SimulatorInstance` interfaces to include the `port` attribute. [[1]](diffhunk://#diff-b8b77f5be18cf56dca425b3a5b8e9d2e754dd37fe0e3612b95cd4e9bccda08a5R7) [[2]](diffhunk://#diff-b8b77f5be18cf56dca425b3a5b8e9d2e754dd37fe0e3612b95cd4e9bccda08a5R28)

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R12): Updated the description and features of PMSim to reflect the new capabilities, including the selection of serial interfaces for Modbus RTU simulations.